### PR TITLE
NullObjectPattern for RSCPData

### DIFF
--- a/src/main/java/io/github/bvotteler/rscp/RSCPData.java
+++ b/src/main/java/io/github/bvotteler/rscp/RSCPData.java
@@ -41,6 +41,9 @@ public class RSCPData {
     private final short dataLength;
     private final byte[] value; // unknown size
 
+    /* NullObjectPattern */
+    public static RSCPData NULL = RSCPData.builder().tag(RSCPTag.TAG_NONE).noneValue().build();
+
     RSCPData(RSCPTag dataTag, RSCPDataType dataType, byte[] value) {
         this.dataTag = dataTag;
         this.dataType = dataType;

--- a/src/main/java/io/github/bvotteler/rscp/RSCPTag.java
+++ b/src/main/java/io/github/bvotteler/rscp/RSCPTag.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum RSCPTag {
+    TAG_NONE("00000000"),
     TAG_RSCP_REQ_AUTHENTICATION("00000001"),
     TAG_RSCP_AUTHENTICATION_USER("00000002"),
     TAG_RSCP_AUTHENTICATION_PASSWORD("00000003"),


### PR DESCRIPTION
Hi bvotteler,
I will use the NullOjectPattern in case of getOrDefault by following code:
map.getOrDefault(RSCPTag.TAG_INFO_MAC_ADDRESS, RSCPData.NULL).getValueAsString().get();
Thanks for your work!
greatings wisgrill